### PR TITLE
[LOW] Add GitHub Actions publish workflow with npm provenance (fixes #7)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm run build
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `.github/workflows/publish.yml` that triggers on GitHub releases
- Publishes to npm with `--provenance --access public` for n8n verification compliance
- Uses Node.js 20 and requires `NPM_TOKEN` secret to be configured

## Test plan
- [ ] Verify the workflow file syntax is valid
- [ ] Create a GitHub release and confirm the workflow triggers
- [ ] Confirm the published package includes an npm provenance statement

🤖 Generated with [Claude Code](https://claude.com/claude-code)