### PR TITLE
[MEDIUM] Use NodeConnectionType enum for inputs/outputs (fixes #3)

### DIFF
--- a/nodes/Jmap/Jmap.node.ts
+++ b/nodes/Jmap/Jmap.node.ts
@@ -6,6 +6,7 @@ import {
 	INodeType,
 	INodeTypeDescription,
 	IDataObject,
+	NodeConnectionTypes,
 	NodeOperationError,
 } from 'n8n-workflow';
 
@@ -42,8 +43,8 @@ export class Jmap implements INodeType {
 		defaults: {
 			name: 'JMAP',
 		},
-		inputs: ['main'],
-		outputs: ['main'],
+		inputs: [NodeConnectionTypes.Main],
+		outputs: [NodeConnectionTypes.Main],
 		credentials: [
 			{
 				name: 'jmapApi',

--- a/nodes/Jmap/JmapTrigger.node.ts
+++ b/nodes/Jmap/JmapTrigger.node.ts
@@ -6,6 +6,7 @@ import {
 	INodeType,
 	INodeTypeDescription,
 	IPollFunctions,
+	NodeConnectionTypes,
 } from 'n8n-workflow';
 
 import {
@@ -28,7 +29,7 @@ export class JmapTrigger implements INodeType {
 			name: 'JMAP Trigger',
 		},
 		inputs: [],
-		outputs: ['main'],
+		outputs: [NodeConnectionTypes.Main],
 		credentials: [
 			{
 				name: 'jmapApi',


### PR DESCRIPTION
## Summary
- Replace bare string literals `'main'` with `NodeConnectionTypes.Main` in `Jmap.node.ts` and `JmapTrigger.node.ts`
- Import `NodeConnectionTypes` from `n8n-workflow` in both files
- Improves type safety and follows n8n best practices

## Test plan
- [x] `npm run build` compiles successfully
- [ ] Verify node still works correctly in n8n when loaded

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)